### PR TITLE
chore: add benchmark mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,7 +142,4 @@ jobs:
       - name: Annotate PR with benchmark artifact links
         run: |
           chmod +x scripts/annotate-pr-benchmark-link.sh
-          echo $GITHUB_REF
-          echo $GITHUB_REF_NAME
-          echo $GITHUB_HEAD_REF
-          ./scripts/annotate-pr-benchmark-link.sh $BRANCH
+          ./scripts/annotate-pr-benchmark-link.sh $GITHUB_HEAD_REF

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -20,7 +20,7 @@ sleep 3
 
 # dns-block
 echo "Starting dns-block benchmark"
-echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53000" -n 1 -t A \
+echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53000" -n 3 -t A \
     --recurse \
     --distribution \
     --csv benchmarks/basic/raw.csv \
@@ -30,7 +30,7 @@ echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53000" -n 1 -t A \
 
 # dns-block-threaded
 echo "Starting dns-block-threaded benchmark"
-echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53001" -n 1 -t A \
+echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53001" -n 3 -t A \
     --recurse \
     --distribution \
     --csv benchmarks/threaded-4/raw.csv \
@@ -40,7 +40,7 @@ echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53001" -n 1 -t A \
 
 # dns-block-tokio
 echo "Starting dns-block-tokio benchmark"
-echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53002" -n 1 -t A \
+echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53002" -n 3 -t A \
     --recurse \
     --distribution \
     --csv benchmarks/tokio/raw.csv \

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -20,7 +20,7 @@ sleep 3
 
 # dns-block
 echo "Starting dns-block benchmark"
-echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53000" -n 3 -t A \
+echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53000" -n 1 -c 3 -t A \
     --recurse \
     --distribution \
     --csv benchmarks/basic/raw.csv \
@@ -30,7 +30,7 @@ echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53000" -n 3 -t A \
 
 # dns-block-threaded
 echo "Starting dns-block-threaded benchmark"
-echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53001" -n 3 -t A \
+echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53001" -n 1 -c 3 -t A \
     --recurse \
     --distribution \
     --csv benchmarks/threaded-4/raw.csv \
@@ -40,7 +40,7 @@ echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53001" -n 3 -t A \
 
 # dns-block-tokio
 echo "Starting dns-block-tokio benchmark"
-echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53002" -n 3 -t A \
+echo $DOMAINS_100 | xargs dnspyre -s "127.0.0.1:53002" -n 1 -c 3 -t A \
     --recurse \
     --distribution \
     --csv benchmarks/tokio/raw.csv \

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -9,11 +9,11 @@ export PATH="./releases:./target/release:$PATH"
 
 mkdir -p benchmarks/{basic,threaded-4,tokio}
 
-PORT=53000 dns-block &
+DNS_BENCHMARK=true PORT=53000 dns-block &
 echo "Started dns-block"
-PORT=53001 dns-block-threaded &
+DNS_BENCHMARK=true PORT=53001 dns-block-threaded &
 echo "Started dns-block-threaded"
-PORT=53002 dns-block-tokio &
+DNS_BENCHMARK=true PORT=53002 dns-block-tokio &
 echo "Started dns-block-tokio"
 
 sleep 3

--- a/crates/dns-block-tokio/src/main.rs
+++ b/crates/dns-block-tokio/src/main.rs
@@ -4,7 +4,7 @@ use tokio::net::UdpSocket;
 use dns::{
     dns::generate_response,
     filter::apply_domain_filter,
-    resolver::{extract_query_id_and_domain, resolve_domain_async},
+    resolver::{extract_query_id_and_domain, resolve_domain_async, resolve_domain_async_benchmark},
 };
 
 const DEFAULT_DNS: &str = "1.1.1.1:53";
@@ -17,9 +17,12 @@ async fn main() {
         .unwrap_or_else(|_| DEFAULT_PORT.into())
         .parse()
         .expect("Port must be a number");
+    let is_benchmark: bool = std::env::var("DNS_BENCHMARK")
+        .map(|x| !x.is_empty())
+        .unwrap_or_else(|_| false);
     let socket = Arc::new(UdpSocket::bind(("0.0.0.0", port)).await.unwrap());
 
-    println!("Started DNS blocker on 127.0.0.1::{port}");
+    println!("Started DNS blocker on 127.0.0.1::{port} [benchmark={is_benchmark}]");
 
     loop {
         let mut buf = [0; 512];
@@ -29,7 +32,9 @@ async fn main() {
         let dns = Arc::clone(&dns);
 
         tokio::task::spawn(async move {
-            process(&socket, &dns, buf, sender).await.unwrap();
+            process(&socket, &dns, buf, sender, is_benchmark)
+                .await
+                .unwrap();
         });
     }
 }
@@ -39,6 +44,7 @@ async fn process(
     dns: &str,
     buf: [u8; 512],
     sender: SocketAddr,
+    is_benchmark: bool,
 ) -> Result<(), ()> {
     let (request_id, question) = extract_query_id_and_domain(buf).unwrap();
     // todo implement async resolve
@@ -47,6 +53,14 @@ async fn process(
         let nx_response = generate_response(request_id, dns::dns::ResponseCode::NXDOMAIN).unwrap();
         socket.send_to(&nx_response, sender).await.unwrap();
     } else {
+        if is_benchmark {
+            let (_, reply) =
+                resolve_domain_async_benchmark(&question.domain_name, dns, Some(request_id), None)
+                    .await
+                    .unwrap();
+            socket.send_to(&reply, sender).await.unwrap();
+            return Ok(());
+        }
         match resolve_domain_async(&question.domain_name, dns, Some(request_id), None).await {
             Ok((_, reply)) => {
                 socket.send_to(&reply, sender).await.unwrap();

--- a/crates/dns-block/src/main.rs
+++ b/crates/dns-block/src/main.rs
@@ -3,7 +3,7 @@ use std::{net::UdpSocket, time::Duration};
 use dns::{
     dns::generate_response,
     filter::apply_domain_filter,
-    resolver::{extract_query_id_and_domain, resolve_domain},
+    resolver::{extract_query_id_and_domain, resolve_domain, resolve_domain_benchmark},
 };
 
 const DEFAULT_UPSTREAM_DNS: &str = "1.1.1.1:53";
@@ -16,6 +16,9 @@ fn main() {
         .unwrap_or_else(|_| DEFAULT_PORT.into())
         .parse()
         .expect("Port must be a number");
+    let is_benchmark: bool = std::env::var("DNS_BENCHMARK")
+        .map(|x| !x.is_empty())
+        .unwrap_or_else(|_| false);
 
     let incoming_socket = UdpSocket::bind(("0.0.0.0", dns_port)).unwrap();
     let outcoming_socket = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
@@ -23,7 +26,7 @@ fn main() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    println!("Started DNS blocker on 127.0.0.1::{dns_port}");
+    println!("Started DNS blocker on 127.0.0.1::{dns_port} [benchmark={is_benchmark}]");
 
     let mut incoming_query = [0; 512];
     loop {
@@ -37,6 +40,18 @@ fn main() {
                     generate_response(request_id, dns::dns::ResponseCode::NXDOMAIN).unwrap();
                 incoming_socket.send_to(&nx_response, sender).unwrap();
             } else {
+                if is_benchmark {
+                    let (_, reply) = resolve_domain_benchmark(
+                        &question.domain_name,
+                        &upstream_dns_host,
+                        Some(request_id),
+                        Some(outcoming_socket.try_clone().unwrap()),
+                    )
+                    .unwrap();
+                    incoming_socket.send_to(&reply, sender).unwrap();
+                    continue;
+                }
+
                 match resolve_domain(
                     &question.domain_name,
                     &upstream_dns_host,

--- a/crates/dns/src/resolver.rs
+++ b/crates/dns/src/resolver.rs
@@ -1,6 +1,8 @@
-use crate::dns::{encode_domain_name, Answer, DnsParser, Question};
+use crate::dns::{
+    encode_domain_name, generate_response, Answer, DnsParser, Question, ResponseCode,
+};
 
-use std::net::UdpSocket;
+use std::{net::UdpSocket, time::Duration};
 
 /// Resolves INternet A records for `domain` using the DNS server `dns`
 pub fn resolve_domain(
@@ -24,6 +26,17 @@ pub fn resolve_domain(
     })?;
 
     parse_answers(buffer)
+}
+
+pub fn resolve_domain_benchmark(
+    _domain: &str,
+    _dns: &str,
+    id: Option<u16>,
+    _socket: Option<UdpSocket>,
+) -> Result<(Vec<Answer>, Vec<u8>), Box<dyn std::error::Error + Send + Sync>> {
+    let response = generate_response(id.unwrap_or(1337), ResponseCode::NOERROR).unwrap();
+    std::thread::sleep(Duration::from_micros(100));
+    parse_answers(response)
 }
 
 pub async fn resolve_domain_async(
@@ -51,6 +64,17 @@ pub async fn resolve_domain_async(
     })?;
 
     parse_answers(buffer)
+}
+
+pub async fn resolve_domain_async_benchmark(
+    _domain: &str,
+    _dns: &str,
+    id: Option<u16>,
+    _existing_socket: Option<tokio::net::UdpSocket>,
+) -> Result<(Vec<Answer>, Vec<u8>), Box<dyn std::error::Error + Send + Sync>> {
+    let response = generate_response(id.unwrap_or(1337), ResponseCode::NOERROR).unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    parse_answers(response)
 }
 
 fn parse_answers(


### PR DESCRIPTION
Benchmark mode avoids actually sending out DNS queries upstream but answers with a pre-defined, empty DNS response.

We do this in order to eliminate any volatility in upstream DNS and network problems to make our benchmarks more meaningful, before we focus on implementing performance improvements.

Of course, real-world benchmarks should not just exclude half of the network stack work, but we need a more stable and consistent benchmarking environment for that, ie. I don't trust GitHub action runners with this.